### PR TITLE
Use project name from definition rather than dir name

### DIFF
--- a/cache/cache_test.go
+++ b/cache/cache_test.go
@@ -105,6 +105,6 @@ func TestCacheKey(t *testing.T) {
 	// fmt.Println(string(js))
 
 	// Known / golden values
-	assert.Equal(t, "cabde3ac0590ab19340462312ecc17efa325e606", key1Str)
-	assert.Equal(t, "fddc8bd0d99a8e5ecb94f89aa020f232b38df2fd", key2Str)
+	assert.Equal(t, "f20681bd6fb3c73e31cb113b6d9ecd8f754aaeaf", key1Str)
+	assert.Equal(t, "8ed8160f86a649cca8cd942cf524e8130b0b246c", key2Str)
 }

--- a/project/project.go
+++ b/project/project.go
@@ -17,6 +17,7 @@ import (
 // Project is a collection of Components that can be built and deployed
 type Project struct {
 	sync.Mutex
+	name            string
 	root            string
 	rootAbs         string
 	artifacts       string
@@ -84,6 +85,10 @@ func NewWithOptions(opts Opts) (*Project, error) {
 		executor:        executor,
 	}
 
+	if opts.ProjectDef != nil {
+		p.name = opts.ProjectDef.Name
+	}
+
 	for _, provider := range opts.Providers {
 		p.providers[provider.Name()] = provider
 		if opts.ProjectDef != nil {
@@ -122,7 +127,7 @@ func (p *Project) resolveDeps() error {
 
 // Name of the project
 func (p *Project) Name() string {
-	return path.Base(p.RootAbsPath())
+	return p.name
 }
 
 // Components returns all Components within the project

--- a/project/project_test.go
+++ b/project/project_test.go
@@ -84,7 +84,13 @@ func TestNewProject(t *testing.T) {
 		},
 	}
 
-	p, err := NewWithOptions(Opts{Root: dir, ComponentDefs: defs})
+	projDef := &definitions.Project{Name: "example"}
+
+	p, err := NewWithOptions(Opts{
+		Root:          dir,
+		ComponentDefs: defs,
+		ProjectDef:    projDef,
+	})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -100,6 +106,9 @@ func TestNewProject(t *testing.T) {
 	}
 	if components[1].Name() != "b" {
 		t.Error("Expected 'b'")
+	}
+	if p.Name() != "example" {
+		t.Errorf("Incorrect project name: '%s'", p.Name())
 	}
 }
 


### PR DESCRIPTION
Previously the directory name of the repository was used which was problematic when folks cloned to a directory with a different name.