### PR TITLE
Guarantee that a rule refreshes its outputs

### DIFF
--- a/project/file.go
+++ b/project/file.go
@@ -114,3 +114,8 @@ func (f *File) LastModified() (time.Time, error) {
 func (f *File) AsFile() (string, error) {
 	return f.path, nil
 }
+
+// Delete the file from disk
+func (f *File) Delete() error {
+	return os.Remove(f.Path())
+}

--- a/project/image.go
+++ b/project/image.go
@@ -179,3 +179,9 @@ func (img *Image) LastModified() (time.Time, error) {
 func (img *Image) AsFile() (string, error) {
 	return "", errors.New("unsupported")
 }
+
+// Delete the image - not currently implemented
+func (img *Image) Delete() error {
+	// We could do this later if we want
+	return errors.New("unsupported")
+}

--- a/project/resource.go
+++ b/project/resource.go
@@ -35,6 +35,9 @@ type Resource interface {
 	// AsFile returns the path to a file containing the Resource itself, or
 	// a representation of the Resource
 	AsFile() (string, error)
+
+	// Delete the resource
+	Delete() error
 }
 
 // HashFile returns the SHA1 hash of File contents


### PR DESCRIPTION
This avoids potential bugs where a poorly defined rule fails to refresh its outputs and this would otherwise go unnoticed.