### PR TITLE
Resolve export resources at most once

### DIFF
--- a/main.go
+++ b/main.go
@@ -16,8 +16,27 @@ package main
 //go:generate mockgen -source=project/runner.go -package project -destination project/runner_mock.go
 //go:generate mockgen -source=project/exec.go -package project -destination project/exec_mock.go
 
-import "github.com/fugue/zim/cmd"
+import (
+	"log"
+	"os"
+	"runtime/pprof"
+
+	"github.com/fugue/zim/cmd"
+)
 
 func main() {
+
+	if os.Getenv("ZIM_PROFILE") == "1" {
+		f, err := os.Create("cpuprofile.out")
+		if err != nil {
+			log.Fatal("could not create CPU profile: ", err)
+		}
+		defer f.Close()
+		if err := pprof.StartCPUProfile(f); err != nil {
+			log.Fatal("could not start CPU profile: ", err)
+		}
+		defer pprof.StopCPUProfile()
+	}
+
 	cmd.Execute()
 }

--- a/project/component.go
+++ b/project/component.go
@@ -107,14 +107,6 @@ type Toolchain struct {
 	Items []ToolchainItem
 }
 
-// Export defines resources exposed by a Component
-type Export struct {
-	Component *Component
-	Provider  Provider
-	Resources []string
-	Ignore    []string
-}
-
 // Component to build and deploy in a repository
 type Component struct {
 	project      *Project

--- a/project/export.go
+++ b/project/export.go
@@ -1,0 +1,71 @@
+package project
+
+import (
+	"sync"
+)
+
+// Export defines resources exposed by a Component. The resources referenced by
+// an export must be static, which allows the export to be resolved only once.
+type Export struct {
+	Component         *Component
+	Provider          Provider
+	Resources         []string
+	Ignore            []string
+	mutex             sync.Mutex
+	resolvedResources Resources
+	resolvedError     error
+	resolved          bool
+}
+
+// Resolve the specific resources that this export exposes. This often takes
+// a glob-like pattern and finds the corresponding specific list of files.
+// This will be called from multiple goroutines.
+func (e *Export) Resolve() (Resources, error) {
+
+	e.mutex.Lock()
+	defer e.mutex.Unlock()
+
+	// If this export was already resolved to specific resources, then just
+	// return the results we previously saved.
+	if e.resolved {
+		return e.resolvedResources, e.resolvedError
+	}
+
+	// Discover exported resources
+	matches, err := matchResources(e.Component, e.Provider, e.Resources)
+	if err != nil {
+		e.resolved = true
+		e.resolvedError = err
+		return nil, err
+	}
+
+	// Exclude ignored resources
+	ignored, err := matchResources(e.Component, e.Provider, e.Ignore)
+	if err != nil {
+		e.resolved = true
+		e.resolvedError = err
+		return nil, err
+	}
+
+	addedPaths := map[string]bool{}
+	ignoredPaths := map[string]bool{}
+	var resources []Resource
+
+	for _, r := range ignored {
+		ignoredPaths[r.Path()] = true
+	}
+
+	for _, r := range matches {
+		rPath := r.Path()
+		if !addedPaths[rPath] && !ignoredPaths[rPath] {
+			resources = append(resources, r)
+			addedPaths[rPath] = true
+		}
+	}
+
+	// Save the resources for future calls
+	e.resolvedResources = resources
+	e.resolvedError = nil
+	e.resolved = true
+	return resources, nil
+}

--- a/project/rule.go
+++ b/project/rule.go
@@ -422,17 +422,11 @@ func (r *Rule) Inputs() (Resources, error) {
 
 	// Find resources imported from other Components
 	for _, imp := range r.resolvedImports {
-		imports, err := matchResources(imp.Component, imp.Provider, imp.Resources)
+		imports, err := imp.Resolve()
 		if err != nil {
 			return nil, fmt.Errorf("Failed to find import: %s", err)
 		}
 		add(imports)
-
-		ignored, err := matchResources(imp.Component, imp.Provider, imp.Ignore)
-		if err != nil {
-			return nil, fmt.Errorf("Failed to ignore: %s", err)
-		}
-		ignore(ignored)
 	}
 
 	// Return the input resources, less the ignored ones


### PR DESCRIPTION
Enhance exports to resolve their specific resources (files) only once. Subsequent calls to Resolve will return the same results. This is protected by a new mutex on the export which makes concurrent calls safe, which is relevant since an export may be referenced by multiple rules running concurrently.

In our situation, this made a large impact on overall build times in a scenario where everything was cached:

Before:
* 1m 23s
* 1m 09s
* 1m 12s

With this change:
* 19s
* 18s
* 18s
