### PR TITLE
Misc fixes

### DIFF
--- a/definitions/component_test.go
+++ b/definitions/component_test.go
@@ -1,0 +1,54 @@
+package definitions
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMergeComponents(t *testing.T) {
+
+	a := &Component{
+		Name: "",
+		Kind: "go",
+		Toolchain: Toolchain{
+			Items: []ToolchainItem{
+				ToolchainItem{
+					Name:    "go version output",
+					Command: "go version",
+				},
+			},
+		},
+		Exports: map[string]Export{
+			"source": Export{
+				Provider:  "FOO",
+				Resources: []string{"*.go", "*.json"},
+				Ignore:    []string{"*_test.go"},
+			},
+		},
+	}
+
+	b := &Component{
+		Kind: "go",
+		Name: "flubber",
+		Exports: map[string]Export{
+			"source": Export{
+				Resources: []string{"*.go"},
+			},
+		},
+	}
+
+	merged := a.Merge(b)
+
+	assert.Equal(t, "flubber", merged.Name)
+	assert.Equal(t, "go", merged.Kind)
+	require.Len(t, merged.Exports, 1)
+
+	source, ok := merged.Exports["source"]
+	require.True(t, ok)
+
+	assert.Equal(t, "FOO", source.Provider)
+	assert.Equal(t, []string{"*_test.go"}, source.Ignore)
+	assert.Equal(t, []string{"*.go"}, source.Resources)
+}

--- a/definitions/merge.go
+++ b/definitions/merge.go
@@ -1,0 +1,54 @@
+package definitions
+
+func mergeStr(a, b string) string {
+	if b != "" {
+		return b
+	}
+	return a
+}
+
+func mergeInt(a, b int) int {
+	if b != 0 {
+		return b
+	}
+	return a
+}
+
+func mergeBool(a, b bool) bool {
+	if b {
+		return true
+	}
+	return a
+}
+
+func copyStrings(input []string) []string {
+	if input == nil {
+		return nil
+	}
+	result := make([]string, len(input))
+	copy(result, input)
+	return result
+}
+
+func mergeStrings(a, b []string) []string {
+	if len(b) > 0 {
+		return copyStrings(b)
+	}
+	return copyStrings(a)
+}
+
+func copyStringsMap(m map[string]string) map[string]string {
+	result := map[string]string{}
+	for k, v := range m {
+		result[k] = v
+	}
+	return result
+}
+
+func mergeStringsMap(a, b map[string]string) map[string]string {
+	result := copyStringsMap(a)
+	for k, v := range b {
+		result[k] = v
+	}
+	return result
+}

--- a/definitions/rule_test.go
+++ b/definitions/rule_test.go
@@ -1,0 +1,41 @@
+package definitions
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMergeRule(t *testing.T) {
+
+	a := Rule{
+		Inputs:  []string{"main.go"},
+		Outputs: []string{"out"},
+		Requires: []Dependency{
+			Dependency{
+				Rule: "some-other-rule",
+			},
+		},
+		Native: true,
+		Commands: []interface{}{
+			map[string]interface{}{"run": "echo HELLO"},
+		},
+	}
+
+	b := Rule{
+		Command: "echo GOODBYE",
+	}
+
+	merged := mergeRule(a, b)
+
+	assert.Equal(t, []string{"main.go"}, merged.Inputs)
+	assert.Equal(t, []string{"out"}, merged.Outputs)
+	assert.Equal(t, []Dependency{
+		Dependency{
+			Rule: "some-other-rule",
+		},
+	}, merged.Requires)
+	assert.Equal(t, true, merged.Native)
+	assert.Nil(t, merged.Commands)
+	assert.Equal(t, "echo GOODBYE", merged.Command)
+}

--- a/project/runner.go
+++ b/project/runner.go
@@ -217,7 +217,11 @@ func (runner *StandardRunner) execRunCommand(
 	execOpts ExecOpts,
 	cmd *Command,
 ) error {
-	execOpts.Command = cmd.Argument
+	script := strings.TrimSpace(cmd.Argument)
+	if script == "" {
+		return nil
+	}
+	execOpts.Command = script
 	return executor.Execute(ctx, execOpts)
 }
 


### PR DESCRIPTION
1. Fix issue where a component's rule that specifies a `command` wasn't overriding `commands` from the kind template
2. Fix issue where exports were not being merged in the same way as rules
3. Don't run empty commands

Not running empty commands just cleans up the output in some situations.