### PR TITLE
Use stdin for sending command to bash

### DIFF
--- a/project/exec_docker_test.go
+++ b/project/exec_docker_test.go
@@ -33,3 +33,28 @@ func TestExecDocker(t *testing.T) {
 
 	fmt.Println("OUT:", stdout.String())
 }
+
+func TestExecDockerMultiline(t *testing.T) {
+	fmt.Println("OK")
+
+	tmpDir, err := ioutil.TempDir("", "zim-test-")
+	require.Nil(t, err)
+
+	stdout := &bytes.Buffer{}
+
+	exec := NewDockerExecutor(tmpDir)
+	err = exec.Execute(context.Background(), ExecOpts{
+		Name: "test",
+		Command: `echo foo
+# This is a comment.
+echo bar
+`,
+		Image:            "fugue2/builder:0.0.3",
+		Stdout:           stdout,
+		Stderr:           stdout,
+		WorkingDirectory: tmpDir,
+	})
+	require.Nil(t, err)
+
+	require.Equal(t, "foo\nbar\n", stdout.String())
+}

--- a/project/exec_test.go
+++ b/project/exec_test.go
@@ -49,3 +49,22 @@ func TestBashExecutor(t *testing.T) {
 		t.Error("Unexpected output:", out)
 	}
 }
+
+func TestBashExecutorMultiline(t *testing.T) {
+	dir := testDir()
+	ctx := context.Background()
+	e := NewBashExecutor()
+
+	var stdout bytes.Buffer
+
+	err := e.Execute(ctx, ExecOpts{
+		Command: `
+echo foo
+# This is a comment
+echo bar`,
+		WorkingDirectory: dir,
+		Stdout:           &stdout,
+	})
+	require.Nil(t, err)
+	require.Equal(t, "foo\nbar\n", stdout.String())
+}


### PR DESCRIPTION
This helps avoid possible issues with multiline commands, such as comments,
heredocs, line continuations using `\`.