### PR TITLE
Support all build variables in rule conditions

### DIFF
--- a/project/condition_test.go
+++ b/project/condition_test.go
@@ -49,32 +49,33 @@ func TestRuleCondition(t *testing.T) {
 		Debug:       false,
 	}
 	ctx := context.Background()
+	env := map[string]string{}
 
 	// "when" condition is true
 	build, found := comp.Rule("build-when-run")
 	require.True(t, found)
-	conditionsMet, err := CheckConditions(ctx, build, execOpts, executor)
+	conditionsMet, err := CheckConditions(ctx, build, execOpts, executor, env)
 	require.Nil(t, err)
 	require.True(t, conditionsMet)
 
 	// "when" condition is false
 	build, found = comp.Rule("build-when-skip")
 	require.True(t, found)
-	conditionsMet, err = CheckConditions(ctx, build, execOpts, executor)
+	conditionsMet, err = CheckConditions(ctx, build, execOpts, executor, env)
 	require.Nil(t, err)
 	require.False(t, conditionsMet)
 
 	// "unless" condition is false (so the rule should run)
 	build, found = comp.Rule("build-unless-run")
 	require.True(t, found)
-	conditionsMet, err = CheckConditions(ctx, build, execOpts, executor)
+	conditionsMet, err = CheckConditions(ctx, build, execOpts, executor, env)
 	require.Nil(t, err)
 	require.True(t, conditionsMet)
 
 	// "unless" condition is true (so the rule should NOT run)
 	build, found = comp.Rule("build-unless-skip")
 	require.True(t, found)
-	conditionsMet, err = CheckConditions(ctx, build, execOpts, executor)
+	conditionsMet, err = CheckConditions(ctx, build, execOpts, executor, env)
 	require.Nil(t, err)
 	require.False(t, conditionsMet)
 }
@@ -85,6 +86,7 @@ func TestConditionScript(t *testing.T) {
 	defer os.RemoveAll(dir)
 	ctx := context.Background()
 	executor := NewBashExecutor()
+	env := map[string]string{}
 
 	c := &Component{name: "test-comp", componentDir: dir}
 	r := &Rule{component: c, name: "test-rule"}
@@ -159,7 +161,7 @@ func TestConditionScript(t *testing.T) {
 			DebugOutput: &stdout,
 			Debug:       false,
 		}
-		conditionsMet, err := CheckCondition(ctx, r, tc.input, runOpts, executor)
+		conditionsMet, err := CheckCondition(ctx, r, tc.input, runOpts, executor, env)
 		if conditionsMet != tc.want {
 			t.Errorf("expected: %v, got: %v", tc.want, conditionsMet)
 		}
@@ -200,6 +202,7 @@ func TestExistsConditions(t *testing.T) {
 		name:       "test-rule",
 		inProvider: fs,
 	}
+	env := map[string]string{}
 
 	type test struct {
 		input   Condition
@@ -233,7 +236,7 @@ func TestExistsConditions(t *testing.T) {
 	for _, tc := range tests {
 		var stdout bytes.Buffer
 		runOpts := RunOpts{Output: &stdout, DebugOutput: &stdout, Debug: false}
-		conditionsMet, err := CheckCondition(ctx, r, tc.input, runOpts, executor)
+		conditionsMet, err := CheckCondition(ctx, r, tc.input, runOpts, executor, env)
 		if conditionsMet != tc.want {
 			t.Errorf("expected: %v, got: %v", tc.want, conditionsMet)
 		}

--- a/project/rule.go
+++ b/project/rule.go
@@ -126,20 +126,20 @@ func NewRule(name string, c *Component, self *definitions.Rule) (*Rule, error) {
 	r.ignore = substituteVarsSlice(r.ignore, variables)
 	r.outputs = substituteVarsSlice(r.outputs, variables)
 	r.when = Condition{
-		ResourceExists:  substituteVars(self.When.ResourceExists, variables),
-		DirectoryExists: substituteVars(self.When.DirectoryExists, variables),
+		ResourceExists:  self.When.ResourceExists,
+		DirectoryExists: self.When.DirectoryExists,
 		ScriptSucceeds: ConditionScript{
-			Run:           substituteVars(self.When.ScriptSucceeds.Run, variables),
-			WithOutput:    substituteVars(self.When.ScriptSucceeds.WithOutput, variables),
+			Run:           self.When.ScriptSucceeds.Run,
+			WithOutput:    self.When.ScriptSucceeds.WithOutput,
 			SuppressError: self.When.ScriptSucceeds.SuppressError,
 		},
 	}
 	r.unless = Condition{
-		ResourceExists:  substituteVars(self.Unless.ResourceExists, variables),
-		DirectoryExists: substituteVars(self.Unless.DirectoryExists, variables),
+		ResourceExists:  self.Unless.ResourceExists,
+		DirectoryExists: self.Unless.DirectoryExists,
 		ScriptSucceeds: ConditionScript{
-			Run:           substituteVars(self.Unless.ScriptSucceeds.Run, variables),
-			WithOutput:    substituteVars(self.Unless.ScriptSucceeds.WithOutput, variables),
+			Run:           self.Unless.ScriptSucceeds.Run,
+			WithOutput:    self.Unless.ScriptSucceeds.WithOutput,
 			SuppressError: self.Unless.ScriptSucceeds.SuppressError,
 		},
 	}


### PR DESCRIPTION
These changes add support for all build variables in `when` and `unless` rule conditions. See https://github.com/fugue/zim/issues/24

For example, conditions like this are now possible:

```yaml
  example:
    native: true
    commands:
      - run: "echo OK"
    when:
      script_succeeds:
        with_output: ${ARTIFACTS_DIR}
        run: echo ${ARTIFACTS_DIR}
```

Previously `ARTIFACTS_DIR`, `ROOT`, `INPUT`, `OUTPUT`, and similar build variables were not supported here.

The full list of supported variables is now:

 * COMPONENT
 * KIND
 * NAME
 * NODE_ID
 * RULE
 * ARTIFACTS_DIR
 * DEP
 * DEPS
 * INPUT
 * OUTPUT
 * OUTPUTS
 * ROOT
 