### PR TITLE
Multi-arch support

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,6 +236,26 @@ rules:
     command: uname -a
 ```
 
+## Docker Platforms
+
+You may target different architectures using Docker's [multi-CPU architecture support](https://docs.docker.com/desktop/multi-arch). To set the Docker target platform, set `platform` in `~/.zim.yaml` as follows:
+
+```yaml
+platform: linux/amd64
+```
+
+Or use the command line flag:
+
+```shell
+$ zim run build --platform linux/amd64
+```
+
+You can list available platforms in Docker by running:
+
+```shell
+$ docker buildx ls
+```
+
 ## Rule Keys
 
 These keys are the basis for Zim caching. Zim uses SHA1 hashes to represent each

--- a/cmd/helpers.go
+++ b/cmd/helpers.go
@@ -72,6 +72,7 @@ type zimOptions struct {
 	Jobs       int
 	CacheMode  string
 	Token      string
+	Platform   string
 }
 
 func getZimOptions(cmd *cobra.Command, args []string) zimOptions {
@@ -89,6 +90,7 @@ func getZimOptions(cmd *cobra.Command, args []string) zimOptions {
 		Jobs:       viper.GetInt("jobs"),
 		CacheMode:  viper.GetString("cache"),
 		Token:      viper.GetString("token"),
+		Platform:   viper.GetString("platform"),
 	}
 	if opts.Cache == "" {
 		opts.Cache = XDGCache()

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -50,6 +50,7 @@ func init() {
 	rootCmd.PersistentFlags().StringSliceP("rules", "r", nil, "Rules to run against components")
 	rootCmd.PersistentFlags().String("cache", "read-write", "Cache mode (read-write | write-only | disabled)")
 	rootCmd.PersistentFlags().String("output", "buffered", "Output mode (buffered | unbuffered)")
+	rootCmd.PersistentFlags().String("platform", "", "Docker target platform (linux/amd64, linux/arm64, ...)")
 
 	// Bind flags to environment variables if they are present
 	viper.BindPFlag("url", rootCmd.PersistentFlags().Lookup("url"))
@@ -62,6 +63,7 @@ func init() {
 	viper.BindPFlag("rules", rootCmd.PersistentFlags().Lookup("rules"))
 	viper.BindPFlag("cache", rootCmd.PersistentFlags().Lookup("cache"))
 	viper.BindPFlag("output", rootCmd.PersistentFlags().Lookup("output"))
+	viper.BindPFlag("platform", rootCmd.PersistentFlags().Lookup("platform"))
 
 	// Flag completions
 	rootCmd.RegisterFlagCompletionFunc("components", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -72,7 +72,7 @@ func NewRunCommand() *cobra.Command {
 
 			var executor exec.Executor
 			if opts.UseDocker {
-				executor = exec.NewDockerExecutor(opts.Directory)
+				executor = exec.NewDockerExecutor(opts.Directory, opts.Platform)
 			} else {
 				executor = exec.NewBashExecutor()
 			}

--- a/cmd/showKey.go
+++ b/cmd/showKey.go
@@ -60,7 +60,7 @@ func NewShowKeyCommand() *cobra.Command {
 
 			var executor exec.Executor
 			if opts.UseDocker {
-				executor = exec.NewDockerExecutor(opts.Directory)
+				executor = exec.NewDockerExecutor(opts.Directory, opts.Platform)
 			} else {
 				executor = exec.NewBashExecutor()
 			}

--- a/exec/exec_docker.go
+++ b/exec/exec_docker.go
@@ -34,7 +34,7 @@ import (
 const DefaultDockerExecutorDir = "/build"
 
 // NewDockerExecutor returns an Executor that runs commands within containers
-func NewDockerExecutor(mountDirectory string) Executor {
+func NewDockerExecutor(mountDirectory, platform string) Executor {
 
 	var userID, groupID string
 
@@ -48,6 +48,7 @@ func NewDockerExecutor(mountDirectory string) Executor {
 		UserID:         userID,
 		GroupID:        groupID,
 		ExecDirectory:  DefaultDockerExecutorDir,
+		Platform:       platform,
 	}
 }
 
@@ -56,6 +57,7 @@ type dockerExecutor struct {
 	UserID         string
 	GroupID        string
 	ExecDirectory  string
+	Platform       string
 }
 
 // Execute runs a command in a container
@@ -109,6 +111,9 @@ func (e *dockerExecutor) Execute(ctx context.Context, opts ExecOpts) error {
 	if os.Getenv("ZIM_DOCKER_IN_DOCKER") == "1" {
 		args = extendSlice(args, "--group-add", "root")
 		args = extendSlice(args, "--volume", "/var/run/docker.sock:/var/run/docker.sock")
+	}
+	if e.Platform != "" {
+		args = extendSlice(args, "--platform", e.Platform)
 	}
 	for _, envVar := range opts.Env {
 		args = extendSlice(args, "-e", envVar)


### PR DESCRIPTION
This PR allows specifying an explicit platform when running rules in Docker. This can be used to target `linux/amd64` when running on Apple M1 macbooks, for example.