### PR TITLE
Draft support for a local filesystem cache

### DIFF
--- a/cache/cache_test.go
+++ b/cache/cache_test.go
@@ -65,14 +65,14 @@ func TestCacheKey(t *testing.T) {
 		Path:   cPath("component.yaml"),
 		Docker: definitions.Docker{Image: "repo/img:1.2.3"},
 		Rules: map[string]definitions.Rule{
-			"test": definitions.Rule{
+			"test": {
 				Description: "test it!",
 				Inputs:      []string{"${NAME}_test.go", "go.mod"},
 				Ignore:      []string{"exclude_me.go"},
 				Outputs:     []string{"test_results"},
 				Command:     "go test -v",
 			},
-			"build": definitions.Rule{
+			"build": {
 				Description: "build it!",
 				Inputs:      []string{"${NAME}.go", "go.mod"},
 				Ignore:      []string{"exclude_me.go"},
@@ -110,7 +110,7 @@ func TestCacheKey(t *testing.T) {
 	buildDeps := buildRule.Dependencies()
 	require.Len(t, buildDeps, 1)
 
-	cache := New(nil)
+	cache := New(Opts{})
 
 	key1, err := cache.Key(ctx, testRule)
 	require.Nil(t, err, "Error getting cache key")
@@ -149,7 +149,7 @@ func TestCacheKeyNonDocker(t *testing.T) {
 		Name: "my-component",
 		Path: path.Join(cDir, "component.yaml"),
 		Rules: map[string]definitions.Rule{
-			"test": definitions.Rule{
+			"test": {
 				Inputs:  []string{"main.go"},
 				Outputs: []string{"my-exe"},
 				Command: "touch my-exe",
@@ -170,7 +170,7 @@ func TestCacheKeyNonDocker(t *testing.T) {
 	require.NotNil(t, c)
 	testRule := c.MustRule("test")
 
-	cache := New(nil)
+	cache := New(Opts{})
 
 	key, err := cache.Key(ctx, testRule)
 	require.Nil(t, err, "Error getting cache key")

--- a/cache/entry.go
+++ b/cache/entry.go
@@ -1,0 +1,32 @@
+// Copyright 2020 Fugue, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cache
+
+// Entry carries the name and hash for one item within a Key
+type Entry struct {
+	Name string `json:"name"`
+	Hash string `json:"hash"`
+}
+
+// command is the contribution to a cache key from a rule command
+type command struct {
+	Kind       string                 `json:"kind"`
+	Argument   string                 `json:"argument,omitempty"`
+	Attributes map[string]interface{} `json:"attributes,omitempty"`
+}
+
+func newEntry(name, hash string) *Entry {
+	return &Entry{Name: name, Hash: hash}
+}

--- a/cache/key.go
+++ b/cache/key.go
@@ -1,0 +1,39 @@
+package cache
+
+import (
+	"crypto/sha1"
+	"encoding/hex"
+	"encoding/json"
+)
+
+// Key contains information used to build a key
+type Key struct {
+	Project     string   `json:"project"`
+	Component   string   `json:"component"`
+	Rule        string   `json:"rule"`
+	Image       string   `json:"image"`
+	OutputCount int      `json:"output_count"`
+	Inputs      []*Entry `json:"inputs"`
+	Deps        []*Entry `json:"deps"`
+	Env         []*Entry `json:"env"`
+	Toolchain   []*Entry `json:"toolchain"`
+	Version     string   `json:"version"`
+	Commands    []string `json:"commands"`
+	Native      bool     `json:"native,omitempty"`
+	hex         string
+}
+
+// String returns the key as a hexadecimal string
+func (k *Key) String() string {
+	return k.hex
+}
+
+// Compute determines the hash for this key
+func (k *Key) Compute() error {
+	h := sha1.New()
+	if err := json.NewEncoder(h).Encode(k); err != nil {
+		return err
+	}
+	k.hex = hex.EncodeToString(h.Sum(nil))
+	return nil
+}

--- a/cache/middleware.go
+++ b/cache/middleware.go
@@ -1,0 +1,61 @@
+// Copyright 2020 Fugue, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cache
+
+import (
+	"context"
+
+	"github.com/fugue/zim/project"
+)
+
+// NewMiddleware returns caching middleware
+func NewMiddleware(c *Cache) project.RunnerBuilder {
+
+	return project.RunnerBuilder(func(runner project.Runner) project.Runner {
+
+		return project.RunnerFunc(func(ctx context.Context, r *project.Rule, opts project.RunOpts) (project.Code, error) {
+
+			// Caching is only applicable for rules that have cacheable
+			// outputs. If this is not the case, run the rule normally.
+			outputs := r.Outputs()
+			if len(outputs) == 0 || !outputs[0].Cacheable() {
+				return runner.Run(ctx, r, opts)
+			}
+
+			if c.mode != WriteOnly {
+				// Download matching outputs from the cache if they exist
+				_, err := c.Read(ctx, r)
+				if err == nil {
+					return project.Cached, nil // Cache hit
+				}
+				if err != CacheMiss {
+					return project.Error, err // Cache error
+				}
+			}
+
+			// At this point, the outputs were not cached so build the rule
+			code, err := runner.Run(ctx, r, opts)
+
+			// Code "OK" indicates the rule was built which means we can
+			// store its outputs in the cache
+			if code == project.OK {
+				if _, err := c.Write(ctx, r); err != nil {
+					return project.Error, err
+				}
+			}
+			return code, err
+		})
+	})
+}

--- a/cache/write.go
+++ b/cache/write.go
@@ -1,0 +1,37 @@
+package cache
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"os"
+)
+
+func writeJSON(key *Key) (string, error) {
+	js, err := json.Marshal(key)
+	if err != nil {
+		return "", err
+	}
+	f, err := ioutil.TempFile("", "zim-key-")
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+	if _, err := f.Write(js); err != nil {
+		return "", err
+	}
+	return f.Name(), nil
+}
+
+func writeKey(path string, key *Key) error {
+	js, err := json.Marshal(key)
+	if err != nil {
+		return err
+	}
+	f, err := os.Create(path)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	_, err = f.Write(js)
+	return err
+}

--- a/cmd/addToken.go
+++ b/cmd/addToken.go
@@ -34,7 +34,11 @@ func NewAddTokenCommand() *cobra.Command {
 		Short: "Add a cache token",
 		Run: func(cmd *cobra.Command, args []string) {
 
-			opts := getZimOptions(cmd, args)
+			opts, err := getZimOptions(cmd, args)
+			if err != nil {
+				fatal(err)
+			}
+
 			name := viper.GetString("name")
 			email := viper.GetString("email")
 

--- a/cmd/listComponents.go
+++ b/cmd/listComponents.go
@@ -41,7 +41,10 @@ func NewListComponentsCommand() *cobra.Command {
 		Aliases: []string{"c"},
 		Run: func(cmd *cobra.Command, args []string) {
 
-			opts := getZimOptions(cmd, args)
+			opts, err := getZimOptions(cmd, args)
+			if err != nil {
+				fatal(err)
+			}
 			proj, err := getProject(opts.Directory)
 			if err != nil {
 				fatal(err)

--- a/cmd/listEnv.go
+++ b/cmd/listEnv.go
@@ -32,12 +32,17 @@ var listEnvCmd = &cobra.Command{
 	Short: "List zim environment and configuration",
 	Run: func(cmd *cobra.Command, args []string) {
 
+		opts, err := getZimOptions(cmd, args)
+		if err != nil {
+			fatal(err)
+		}
+
 		defaultCols := []string{
 			"Key",
 			"Value",
 		}
 
-		fields := structs.Map(getZimOptions(cmd, args))
+		fields := structs.Map(opts)
 
 		var rows []interface{}
 		for _, k := range []string{"URL", "Region", "Debug", "Jobs", "UseDocker"} {

--- a/cmd/listInputs.go
+++ b/cmd/listInputs.go
@@ -41,7 +41,10 @@ func NewListInputsCommand() *cobra.Command {
 		Aliases: []string{"in", "ins", "inputs"},
 		Run: func(cmd *cobra.Command, args []string) {
 
-			opts := getZimOptions(cmd, args)
+			opts, err := getZimOptions(cmd, args)
+			if err != nil {
+				fatal(err)
+			}
 			proj, err := getProject(opts.Directory)
 			if err != nil {
 				fatal(err)

--- a/cmd/listOutputs.go
+++ b/cmd/listOutputs.go
@@ -44,7 +44,10 @@ func NewListArtifactsCommand() *cobra.Command {
 		Aliases: []string{"out", "outs", "outputs"},
 		Run: func(cmd *cobra.Command, args []string) {
 
-			opts := getZimOptions(cmd, args)
+			opts, err := getZimOptions(cmd, args)
+			if err != nil {
+				fatal(err)
+			}
 			proj, err := getProject(opts.Directory)
 			if err != nil {
 				fatal(err)

--- a/cmd/listRules.go
+++ b/cmd/listRules.go
@@ -39,7 +39,10 @@ func NewListRulesCommand() *cobra.Command {
 		Aliases: []string{"r", "rule", "rules"},
 		Run: func(cmd *cobra.Command, args []string) {
 
-			opts := getZimOptions(cmd, args)
+			opts, err := getZimOptions(cmd, args)
+			if err != nil {
+				fatal(err)
+			}
 			proj, err := getProject(opts.Directory)
 			if err != nil {
 				fatal(err)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -67,7 +67,10 @@ func init() {
 
 	// Flag completions
 	rootCmd.RegisterFlagCompletionFunc("components", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		opts := getZimOptions(cmd, args)
+		opts, err := getZimOptions(cmd, args)
+		if err != nil {
+			fatal(err)
+		}
 		proj, err := getProject(opts.Directory)
 		if err != nil {
 			fatal(err)
@@ -85,7 +88,10 @@ func init() {
 	})
 
 	rootCmd.RegisterFlagCompletionFunc("kinds", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		opts := getZimOptions(cmd, args)
+		opts, err := getZimOptions(cmd, args)
+		if err != nil {
+			fatal(err)
+		}
 		proj, err := getProject(opts.Directory)
 		if err != nil {
 			fatal(err)
@@ -99,7 +105,10 @@ func init() {
 	})
 
 	rootCmd.RegisterFlagCompletionFunc("rules", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		opts := getZimOptions(cmd, args)
+		opts, err := getZimOptions(cmd, args)
+		if err != nil {
+			fatal(err)
+		}
 		proj, err := getProject(opts.Directory)
 		if err != nil {
 			fatal(err)

--- a/hash/hash.go
+++ b/hash/hash.go
@@ -1,0 +1,15 @@
+package hash
+
+// Hasher is an interface for hashing objects, files, or strings.
+// Different implementations may exist for SHA1, SHA256, etc.
+type Hasher interface {
+
+	// Object returns the hash of a given object
+	Object(obj interface{}) (string, error)
+
+	// File returns the hash of a given file on disk
+	File(path string) (string, error)
+
+	// String returns the hash of a given string
+	String(s string) (string, error)
+}

--- a/hash/sha1.go
+++ b/hash/sha1.go
@@ -1,0 +1,44 @@
+package hash
+
+import (
+	"crypto/sha1"
+	"encoding/hex"
+	"encoding/json"
+	"io"
+	"os"
+)
+
+type sha1Hasher struct{}
+
+func SHA1() Hasher {
+	return &sha1Hasher{}
+}
+
+func (hasher *sha1Hasher) Object(obj interface{}) (string, error) {
+	h := sha1.New()
+	if err := json.NewEncoder(h).Encode(obj); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(h.Sum(nil)), nil
+}
+
+func (hasher *sha1Hasher) File(filePath string) (string, error) {
+	file, err := os.Open(filePath)
+	if err != nil {
+		return "", err
+	}
+	defer file.Close()
+	h := sha1.New()
+	if _, err := io.Copy(h, file); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(h.Sum(nil)), nil
+}
+
+func (hasher *sha1Hasher) String(s string) (string, error) {
+	h := sha1.New()
+	if _, err := h.Write([]byte(s)); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(h.Sum(nil)), nil
+}

--- a/hash/sha256.go
+++ b/hash/sha256.go
@@ -1,0 +1,44 @@
+package hash
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"io"
+	"os"
+)
+
+type sha256Hasher struct{}
+
+func SHA256() Hasher {
+	return &sha256Hasher{}
+}
+
+func (hasher *sha256Hasher) Object(obj interface{}) (string, error) {
+	h := sha256.New()
+	if err := json.NewEncoder(h).Encode(obj); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(h.Sum(nil)), nil
+}
+
+func (hasher *sha256Hasher) File(filePath string) (string, error) {
+	file, err := os.Open(filePath)
+	if err != nil {
+		return "", err
+	}
+	defer file.Close()
+	h := sha256.New()
+	if _, err := io.Copy(h, file); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(h.Sum(nil)), nil
+}
+
+func (hasher *sha256Hasher) String(s string) (string, error) {
+	h := sha256.New()
+	if _, err := h.Write([]byte(s)); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(h.Sum(nil)), nil
+}

--- a/store/filesystem/filesystem.go
+++ b/store/filesystem/filesystem.go
@@ -1,0 +1,127 @@
+// Copyright 2020 Fugue, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package filesystem
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+
+	"github.com/fugue/zim/store"
+)
+
+type fileStore struct {
+	rootDirectory string
+}
+
+// New returns a store.Store interface backed by the local filesystem
+func New(rootDirectory string) store.Store {
+	return &fileStore{rootDirectory: rootDirectory}
+}
+
+func (s *fileStore) path(key string) string {
+	if len(key) > 2 {
+		prefix := key[:2]
+		return filepath.Join(s.rootDirectory, prefix, key)
+	}
+	return filepath.Join(s.rootDirectory, key)
+}
+
+func (s *fileStore) Get(ctx context.Context, key, dst string) error {
+
+	path := s.path(key)
+	srcFile, err := os.Open(path)
+	if err != nil {
+		return fmt.Errorf("failed to open file %s: %w", path, err)
+	}
+	defer srcFile.Close()
+
+	return copyFile(srcFile, dst)
+}
+
+func (s *fileStore) Put(ctx context.Context, key, src string, meta map[string]string) error {
+
+	path := s.path(key)
+	pathDir := filepath.Dir(path)
+
+	fmt.Println("PUT", path, pathDir, key)
+
+	if err := os.MkdirAll(pathDir, 0755); err != nil {
+		return err
+	}
+
+	f, err := os.Open(src)
+	if err != nil {
+		return fmt.Errorf("failed to open file %s: %w", src, err)
+	}
+	defer f.Close()
+
+	if err := copyFile(f, path); err != nil {
+		return err
+	}
+
+	metaPath := fmt.Sprintf("%s.meta", path)
+	metaBytes, err := json.Marshal(store.ItemMeta{Meta: meta})
+	if err != nil {
+		return fmt.Errorf("failed to marshal metadata; key: %s err: %w", key, err)
+	}
+	metaFile, err := os.Create(metaPath)
+	if err != nil {
+		return fmt.Errorf("failed to create file %s: %w", metaPath, err)
+	}
+	defer metaFile.Close()
+
+	if _, err := metaFile.Write(metaBytes); err != nil {
+		return fmt.Errorf("failed to write file %s: %w", metaPath, err)
+	}
+	return nil
+}
+
+func copyFile(f *os.File, dstPath string) error {
+
+	dstFile, err := os.Create(dstPath)
+	if err != nil {
+		return fmt.Errorf("failed to create file %s: %w", dstPath, err)
+	}
+	defer dstFile.Close()
+
+	if _, err := io.Copy(dstFile, f); err != nil {
+		return fmt.Errorf("failed to write file %s: %w", dstPath, err)
+	}
+	return nil
+}
+
+// Head checks if the item exists in the store
+func (s *fileStore) Head(ctx context.Context, key string) (store.ItemMeta, error) {
+
+	metaPath := fmt.Sprintf("%s.meta", s.path(key))
+	metaBytes, err := ioutil.ReadFile(metaPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return store.ItemMeta{}, store.NotFound(fmt.Sprintf("Not found: %s", key))
+		}
+		return store.ItemMeta{}, err
+	}
+
+	var itemMeta store.ItemMeta
+	if err := json.Unmarshal(metaBytes, &itemMeta); err != nil {
+		return store.ItemMeta{}, fmt.Errorf("failed to parse metadata: %w", err)
+	}
+	return itemMeta, nil
+}

--- a/store/store.go
+++ b/store/store.go
@@ -11,14 +11,11 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 package store
 
 import (
 	"context"
-	"os"
-	"time"
-
-	"github.com/aws/aws-sdk-go/aws/awserr"
 )
 
 // NotFound indicates an object does not exist
@@ -26,19 +23,9 @@ type NotFound string
 
 func (e NotFound) Error() string { return string(e) }
 
-// Item in storage
-type Item struct {
-	Key          string
-	ETag         string
-	Version      string
-	Size         int64
-	LastModified time.Time
-	Meta         map[string]string
-}
-
-// Exists returns true if it is a valid Item
-func (item Item) Exists() bool {
-	return item.Key != "" && item.ETag != "" && item.Size > 0
+// ItemMeta contains metadata for an item in storage
+type ItemMeta struct {
+	Meta map[string]string `json:"meta"`
 }
 
 // Store is an interface to Get and Put items into storage
@@ -50,28 +37,6 @@ type Store interface {
 	// Put an item in the Store
 	Put(ctx context.Context, key, src string, meta map[string]string) error
 
-	// List contents of the Store
-	List(ctx context.Context, prefix string) ([]string, error)
-
 	// Head checks if the item exists in the store
-	Head(ctx context.Context, key string) (Item, error)
-}
-
-// Returns the size and last modified timestamp for the file at the given path
-func fileStat(name string) (int64, time.Time) {
-	info, err := os.Stat(name)
-	if err != nil {
-		return 0, time.Time{}
-	}
-	return info.Size(), info.ModTime()
-}
-
-func isNotFound(err error) bool {
-	if aerr, ok := err.(awserr.Error); ok {
-		switch aerr.Code() {
-		case "NotFound":
-			return true
-		}
-	}
-	return false
+	Head(ctx context.Context, key string) (ItemMeta, error)
 }


### PR DESCRIPTION
Create and use a local filesystem cache by default, if no remote cache is configured.

This is a _DRAFT_ implementation.

The order of precedence for setting the cache directory is as follows:

1. `ZIM_CACHE_PATH` environment variable, or equivalent setting in `~/.zim.yaml`
2. `${XDG_CACHE_HOME}/zim` if `XDG_CACHE_HOME` is set
3. `${HOME}/.cache/zim`

As it stands, this behavior is activated by default, so anyone using Zim without a cache that gets this update will automatically start using a local cache. We could choose to avoid that if we want, but it would be a more logical default behavior for someone that has just installed Zim.

Relates to: #40 